### PR TITLE
Avoid overlapping agents on init state

### DIFF
--- a/sources/agents.c
+++ b/sources/agents.c
@@ -1,5 +1,19 @@
 #include "../headers/agents.h"
 
+
+void avoid_overlapping_agents_on_starting_state() {
+    for (int a = 0; a < NUM_AGENTS_TYPE_1; a++) {
+        for (int aa = 0; aa < NUM_AGENTS_TYPE_1; aa++) {
+            if (a == aa) continue;
+            if (agent_type_1[a].x_pos == agent_type_1[aa].x_pos && agent_type_1[a].y_pos == agent_type_1[aa].y_pos) {
+                agent_type_1[a].x_pos = gsl_rng_uniform_int(r_rand, NUM_CELLS_PER_COLUMN);
+                agent_type_1[a].y_pos = gsl_rng_uniform_int(r_rand, NUM_CELLS_PER_COLUMN);
+                aa -= 1;
+            }
+        }
+    }
+}
+
 void init_agents_position_and_colour( void ){
   for( int a = 0; a < NUM_AGENTS_TYPE_1; a++){
     agent_type_1[a].x_pos = gsl_rng_uniform_int(r_rand, NUM_CELLS_PER_COLUMN );
@@ -18,6 +32,7 @@ void init_agents_position_and_colour( void ){
     agent_type_2[a].colors[2] = TYPE_2_BLUE;
     agent_type_2[a].shape     = SHAPE_OF_AGENTS_TYPE_2;
   }
+  avoid_overlapping_agents_on_starting_state()
 }
 
 extern void update_agents_positions ( void ){


### PR DESCRIPTION
The init function randomly places agents on the board. It happens that several agents overlap and it is unoticeable.
It therefore seems like there are bugs when coding new features. 

Example: 
I made a count_neigbours function, and it seemed bugged as some agents had more neigbours than the one that could be seen displayed.

I am not sure if students could figure out quickly the issue. Some seeds might work just fine then all their code could crash on a seed with overlapping.